### PR TITLE
blueprint: Use new HAProxy constructor

### DIFF
--- a/wordpress-example.js
+++ b/wordpress-example.js
@@ -2,14 +2,14 @@ const {Machine, createDeployment, githubKeys} = require("@quilt/quilt");
 var wordpress = require("./wordpress.js");
 var memcached = require("@quilt/memcached");
 var mysql = require("@quilt/mysql");
-var haproxy = require("@quilt/haproxy");
+var HaProxy = require("@quilt/haproxy");
 var spark = require("@quilt/spark");
 
 var memcd = new memcached.Memcached(3);
 var db = new mysql.Mysql(2);
 var sprk = new spark.Spark(1, 4); // 1 Master, 4 Workers
 var wp = new wordpress.Wordpress(4, db, memcd);
-var hap = new haproxy.Haproxy(2, wp.wp);
+var hap = new Haproxy(2, wp.wp);
 
 sprk.workers.connect(7077, db.master);
 hap.public();


### PR DESCRIPTION
The blueprint now uses the updated HAProxy blueprint that exports the
constructor directly.